### PR TITLE
Events Seats

### DIFF
--- a/src/main/kotlin/com/ticketera/controller/EventSeatController.kt
+++ b/src/main/kotlin/com/ticketera/controller/EventSeatController.kt
@@ -1,0 +1,64 @@
+package com.ticketera.controller
+
+import com.ticketera.dto.eventSeats.NewEventSeatsDto
+import com.ticketera.exceptions.ErrorMessage
+import com.ticketera.exceptions.TicketeraException
+import com.ticketera.model.EventSeat
+import com.ticketera.service.AuthHeadersService
+import com.ticketera.service.EventSeatService
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.RequestParam
+import java.util.UUID
+
+@RestController
+@RequestMapping("/ticketera/events/seats")
+class EventSeatController(
+    private val headersService: AuthHeadersService,
+    private val eventSeatService: EventSeatService
+) {
+
+    @GetMapping("/{eventId}/all")
+    fun eventSeats(
+        @PathVariable("eventId")
+        eventId: UUID,
+        @RequestParam(required = false)
+        sectorId: UUID?
+    ): List<EventSeat> {
+        return eventSeatService.findSeats(eventId, sectorId)
+    }
+
+
+    @PostMapping("/new")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun newEventSeats(
+        @RequestHeader
+        headers: Map<String, String>,
+        @RequestBody
+        newEventSeatsDto: NewEventSeatsDto
+    ): List<EventSeat> {
+        if (!headersService.isAdminOrOrganizer(headers)) throw TicketeraException(ErrorMessage.INVALID_REQUEST)
+        return eventSeatService.generateEventSeats(newEventSeatsDto)
+    }
+
+    @DeleteMapping("/delete/{eventId}")
+    fun deleteEventSeats(
+        @RequestHeader
+        headers: Map<String, String>,
+        @PathVariable("eventId")
+        eventId: UUID,
+        @RequestParam(required = false)
+        sectorId: UUID?
+    ) {
+        if (!headersService.isAdminOrOrganizer(headers)) throw TicketeraException(ErrorMessage.INVALID_REQUEST)
+        eventSeatService.deleteSeats(eventId, sectorId)
+    }
+}

--- a/src/main/kotlin/com/ticketera/controller/EventSectorController.kt
+++ b/src/main/kotlin/com/ticketera/controller/EventSectorController.kt
@@ -29,12 +29,9 @@ class EventSectorController(
 
     @GetMapping("/{eventId}/all")
     fun eventSectors(
-        @RequestHeader
-        headers: Map<String, String>,
         @PathVariable("eventId")
         eventId: UUID
     ): List<EventSector> {
-        if (!headersService.isAdminOrOrganizer(headers)) throw TicketeraException(ErrorMessage.INVALID_REQUEST)
         return eventSectorService.findByEventId(eventId)
     }
 

--- a/src/main/kotlin/com/ticketera/controller/TicketTypeController.kt
+++ b/src/main/kotlin/com/ticketera/controller/TicketTypeController.kt
@@ -29,12 +29,9 @@ class TicketTypeController(
 
     @GetMapping("/{eventId}/all")
     fun eventTickets(
-        @RequestHeader
-        headers: Map<String, String>,
         @PathVariable("eventId")
         eventId: UUID
     ): List<TicketType> {
-        if (!headersService.isAdminOrOrganizer(headers)) throw TicketeraException(ErrorMessage.INVALID_REQUEST)
         return ticketTypeService.findByEventId(eventId)
     }
 

--- a/src/main/kotlin/com/ticketera/dto/eventSeats/NewEventSeatsDto.kt
+++ b/src/main/kotlin/com/ticketera/dto/eventSeats/NewEventSeatsDto.kt
@@ -1,0 +1,35 @@
+package com.ticketera.dto.eventSeats
+
+import com.ticketera.model.Event
+import com.ticketera.model.EventSeat
+import com.ticketera.model.EventSector
+import java.time.Instant
+import java.util.UUID
+
+data class NewEventSeatsDto(
+    val fromNumber: Int,
+    val toNumber: Int,
+    val label: String,
+    val seatRowInfo: String? = null,
+    val priceAddition: Double? = null,
+    val eventId: UUID,
+    val sectorId: UUID?
+) {
+    companion object {
+
+        fun newEventSeats(dto: NewEventSeatsDto, event: Event, eventSector: EventSector?): List<EventSeat> {
+            return (dto.fromNumber..dto.toNumber).map { number ->
+                EventSeat(
+                    id = UUID.randomUUID(),
+                    event = event,
+                    sector = eventSector,
+                    label = dto.label,
+                    seatRowInfo = dto.seatRowInfo,
+                    seatNumber = number.toString(),
+                    priceAddition = dto.priceAddition,
+                    createdAt = Instant.now().toEpochMilli()
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/ticketera/model/EventSeat.kt
+++ b/src/main/kotlin/com/ticketera/model/EventSeat.kt
@@ -1,0 +1,38 @@
+package com.ticketera.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.FetchType
+import java.util.UUID
+
+@Entity
+@Table(name = "event_seat")
+data class EventSeat(
+    @Id
+    val id: UUID,
+    val label: String,
+
+    @Column(name = "seat_row_info")
+    val seatRowInfo: String? = null,
+
+    @Column(name = "seat_number")
+    val seatNumber: String? = null,
+
+    @Column(name = "price_addition")
+    val priceAddition: Double? = null,
+
+    @Column(name = "created_at", nullable = false)
+    val createdAt: Long,
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "event_id", nullable = false)
+    val event: Event,
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "sector_id", nullable = false)
+    val sector: EventSector?
+)

--- a/src/main/kotlin/com/ticketera/repositories/EventSeatRepository.kt
+++ b/src/main/kotlin/com/ticketera/repositories/EventSeatRepository.kt
@@ -1,0 +1,14 @@
+package com.ticketera.repositories
+
+import com.ticketera.model.EventSeat
+import org.springframework.data.repository.CrudRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface EventSeatRepository : CrudRepository<EventSeat, UUID> {
+    fun deleteByEventId(eventId: UUID)
+    fun deleteByEventIdAndSectorId(eventId: UUID, sectorId: UUID)
+    fun findAllByEventId(eventId: UUID): List<EventSeat>
+    fun findAllByEventIdAndSectorId(eventId: UUID, sectorId: UUID): List<EventSeat>
+}

--- a/src/main/kotlin/com/ticketera/repositories/EventSectorRepository.kt
+++ b/src/main/kotlin/com/ticketera/repositories/EventSectorRepository.kt
@@ -1,7 +1,6 @@
 package com.ticketera.repositories
 
 import com.ticketera.model.EventSector
-import com.ticketera.model.TicketType
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
 import java.util.UUID

--- a/src/main/kotlin/com/ticketera/service/AuthHeadersService.kt
+++ b/src/main/kotlin/com/ticketera/service/AuthHeadersService.kt
@@ -20,6 +20,9 @@ class AuthHeadersService {
             it.roles.contains(UserRole.ADMIN) || it.roles.contains(UserRole.ORGANIZER)
         }
 
+    fun isAUser(headers: Map<String, String>) =
+        getUser(headers).roles.contains(UserRole.USER)
+
     private fun extractRoles(roles: String?) = roles
         ?.split(",")
         ?.mapNotNull { role ->

--- a/src/main/kotlin/com/ticketera/service/EventSeatService.kt
+++ b/src/main/kotlin/com/ticketera/service/EventSeatService.kt
@@ -39,14 +39,14 @@ class EventSeatService(
     }
 
     @Transactional
-    fun deleteSeats(eventId: UUID, sectorId: UUID?) {
+    fun deleteSeats(eventId: UUID, sectorId: UUID? = null) {
         sectorId?.let {
             eventSeatRepository.deleteByEventIdAndSectorId(eventId, it)
         } ?: eventSeatRepository.deleteByEventId(eventId)
     }
 
 
-    fun findSeats(eventId: UUID, sectorId: UUID?) {
+    fun findSeats(eventId: UUID, sectorId: UUID? = null) {
         sectorId?.let {
             eventSeatRepository.findAllByEventIdAndSectorId(eventId, it)
         } ?: eventSeatRepository.findAllByEventId(eventId)

--- a/src/main/kotlin/com/ticketera/service/EventSeatService.kt
+++ b/src/main/kotlin/com/ticketera/service/EventSeatService.kt
@@ -39,16 +39,15 @@ class EventSeatService(
     }
 
     @Transactional
-    fun deleteSeats(eventId: UUID, sectorId: UUID? = null) {
+    fun deleteSeats(eventId: UUID, sectorId: UUID? = null) =
         sectorId?.let {
             eventSeatRepository.deleteByEventIdAndSectorId(eventId, it)
         } ?: eventSeatRepository.deleteByEventId(eventId)
-    }
 
 
-    fun findSeats(eventId: UUID, sectorId: UUID? = null) {
+    fun findSeats(eventId: UUID, sectorId: UUID? = null) =
         sectorId?.let {
             eventSeatRepository.findAllByEventIdAndSectorId(eventId, it)
         } ?: eventSeatRepository.findAllByEventId(eventId)
-    }
+
 }

--- a/src/main/kotlin/com/ticketera/service/EventSeatService.kt
+++ b/src/main/kotlin/com/ticketera/service/EventSeatService.kt
@@ -1,0 +1,54 @@
+package com.ticketera.service
+
+import com.ticketera.dto.eventSeats.NewEventSeatsDto
+import com.ticketera.exceptions.ErrorMessage
+import com.ticketera.exceptions.TicketeraException
+import com.ticketera.model.EventSeat
+import com.ticketera.model.EventSector
+import com.ticketera.repositories.EventRepository
+import com.ticketera.repositories.EventSeatRepository
+import com.ticketera.repositories.EventSectorRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+class EventSeatService(
+    private val eventSeatRepository: EventSeatRepository,
+    private val eventSectorRepository: EventSectorRepository,
+    private val eventRepository: EventRepository
+) {
+
+    fun generateEventSeats(dto: NewEventSeatsDto): List<EventSeat> {
+        val event = eventRepository.findById(dto.eventId).orElseThrow {
+            TicketeraException(ErrorMessage.EVENT_NOT_FOUND)
+        }
+
+        val sector: EventSector? =
+            dto.sectorId?.let {
+                eventSectorRepository.findById(it)
+                    .orElseThrow {
+                        TicketeraException(ErrorMessage.EVENT_NOT_FOUND)
+                    }
+            }
+
+        return eventSeatRepository.saveAll(
+            NewEventSeatsDto
+                .newEventSeats(dto, event, sector)
+        ).toList()
+    }
+
+    @Transactional
+    fun deleteSeats(eventId: UUID, sectorId: UUID?) {
+        sectorId?.let {
+            eventSeatRepository.deleteByEventIdAndSectorId(eventId, it)
+        } ?: eventSeatRepository.deleteByEventId(eventId)
+    }
+
+
+    fun findSeats(eventId: UUID, sectorId: UUID?) {
+        sectorId?.let {
+            eventSeatRepository.findAllByEventIdAndSectorId(eventId, it)
+        } ?: eventSeatRepository.findAllByEventId(eventId)
+    }
+}

--- a/src/test/kotlin/com/ticketera/TestData.kt
+++ b/src/test/kotlin/com/ticketera/TestData.kt
@@ -9,6 +9,7 @@ import com.ticketera.dto.ticketTypes.UpdateTicketTypeDto
 import com.ticketera.dto.venues.NewVenueDto
 import com.ticketera.dto.venues.UpdateVenueDto
 import com.ticketera.model.Event
+import com.ticketera.model.EventSeat
 import com.ticketera.model.EventSector
 import com.ticketera.model.TicketType
 import com.ticketera.model.Venue
@@ -22,6 +23,7 @@ abstract class TestData {
     protected val eventId = UUID.randomUUID()
     protected val ticketTypeId = UUID.randomUUID()
     protected val eventSectorId = UUID.randomUUID()
+    protected val eventSeatId = UUID.randomUUID()
 
     protected val headersMap = mapOf(
         "x-Roles" to "USER,X-USER-ROLE,ADMIN",
@@ -72,6 +74,17 @@ abstract class TestData {
         10.0,
         Instant.now().toEpochMilli(),
         event
+    )
+
+    protected val eventSeat = EventSeat(
+        eventSeatId,
+        "Testing Seat",
+        "Seat on Row X",
+        "10",
+        0.0,
+        Instant.now().toEpochMilli(),
+        event,
+        eventSector
     )
 
 

--- a/src/test/kotlin/com/ticketera/TestData.kt
+++ b/src/test/kotlin/com/ticketera/TestData.kt
@@ -1,5 +1,6 @@
 package com.ticketera
 
+import com.ticketera.dto.eventSeats.NewEventSeatsDto
 import com.ticketera.dto.eventSectors.NewEventSectorDto
 import com.ticketera.dto.eventSectors.UpdateEventSectorDto
 import com.ticketera.dto.events.NewEventDto
@@ -154,5 +155,15 @@ abstract class TestData {
         "updated-testing-sector",
         11.11,
         eventId
+    )
+
+    protected val newEventSeatsDto = NewEventSeatsDto(
+        1,
+        5,
+        "row-0",
+        "row-0",
+        0.0,
+        eventId,
+        eventSectorId
     )
 }

--- a/src/test/kotlin/com/ticketera/controller/EventSeatControllerTest.kt
+++ b/src/test/kotlin/com/ticketera/controller/EventSeatControllerTest.kt
@@ -1,0 +1,92 @@
+package com.ticketera.controller
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import com.ticketera.TestData
+import com.ticketera.service.AuthHeadersService
+import com.ticketera.service.EventSeatService
+import com.ticketera.service.EventSectorService
+import io.mockk.every
+import io.mockk.verify
+import io.mockk.just
+import io.mockk.runs
+import org.assertj.core.api.Assertions.assertThat
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+
+import org.junit.jupiter.api.Test
+
+@WebMvcTest(EventSeatController::class)
+class EventSeatControllerTest : TestData() {
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @MockkBean
+    private lateinit var eventSeatService: EventSeatService
+
+    @MockkBean
+    private lateinit var userAuthHeadersService: AuthHeadersService
+
+    val objectMapper = jacksonObjectMapper()
+
+    @Test
+    fun shouldFetchEventSeats() {
+        every { eventSeatService.findSeats(any(), any()) } returns listOf(eventSeat)
+
+        val response = mvc.perform(
+            get("/ticketera/events/seats/${eventId}/all")
+                .param("sectorId", eventSectorId.toString())
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andReturn().response
+
+        assertThat(response.status).isEqualTo(HttpStatus.OK.value())
+
+        verify { eventSeatService.findSeats(any(), any()) }
+    }
+
+
+    @Test
+    fun shouldCreateEventSeats() {
+        every { eventSeatService.generateEventSeats(any()) } returns listOf(eventSeat)
+        every { userAuthHeadersService.isAdminOrOrganizer(any()) } returns true
+
+        val response = mvc.perform(
+            post("/ticketera/events/seats/new")
+                .headers(httpHeaders)
+                .content(objectMapper.writeValueAsString(newEventSeatsDto))
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andReturn().response
+
+        assertThat(response.status).isEqualTo(HttpStatus.CREATED.value())
+
+        verify { eventSeatService.generateEventSeats(any()) }
+        verify { userAuthHeadersService.isAdminOrOrganizer(any()) }
+    }
+
+    @Test
+    fun shouldDeleteEventSeats() {
+        every { eventSeatService.deleteSeats(any(), any()) } just runs
+        every { userAuthHeadersService.isAdminOrOrganizer(any()) } returns true
+
+        val response = mvc.perform(
+            delete("/ticketera/events/seats/delete/${eventId}")
+                .headers(httpHeaders)
+                .param("sectorId", eventSectorId.toString())
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andReturn().response
+
+        assertThat(response.status).isEqualTo(HttpStatus.OK.value())
+
+        verify { eventSeatService.deleteSeats(any(), any()) }
+        verify { userAuthHeadersService.isAdminOrOrganizer(any()) }
+    }
+}

--- a/src/test/kotlin/com/ticketera/controller/EventSectorControllerTest.kt
+++ b/src/test/kotlin/com/ticketera/controller/EventSectorControllerTest.kt
@@ -41,7 +41,6 @@ class EventSectorControllerTest : TestData() {
     @Test
     fun shouldFetchEventSectors() {
         every { eventSectorService.findByEventId(any()) } returns listOf(eventSector)
-        every { userAuthHeadersService.isAdminOrOrganizer(any()) } returns true
 
         val response = mvc.perform(
             get("/ticketera/events/sector/${eventId}/all")
@@ -50,7 +49,6 @@ class EventSectorControllerTest : TestData() {
 
         assertThat(response.status).isEqualTo(HttpStatus.OK.value())
 
-        verify { userAuthHeadersService.isAdminOrOrganizer(any()) }
         verify { eventSectorService.findByEventId(any()) }
     }
 

--- a/src/test/kotlin/com/ticketera/controller/TicketTypeControllerTest.kt
+++ b/src/test/kotlin/com/ticketera/controller/TicketTypeControllerTest.kt
@@ -41,7 +41,6 @@ class TicketTypeControllerTest : TestData() {
     @Test
     fun shouldFetchEventTicketTypes() {
         every { ticketTypeService.findByEventId(any()) } returns listOf(ticketType)
-        every { userAuthHeadersService.isAdminOrOrganizer(any()) } returns true
 
         val response = mvc.perform(
             get("/ticketera/tickets/types/${eventId}/all")
@@ -50,7 +49,6 @@ class TicketTypeControllerTest : TestData() {
 
         assertThat(response.status).isEqualTo(HttpStatus.OK.value())
 
-        verify { userAuthHeadersService.isAdminOrOrganizer(any()) }
         verify { ticketTypeService.findByEventId(any()) }
     }
 

--- a/src/test/kotlin/com/ticketera/dto/eventSeats/NewEventSeatsDtoTest.kt
+++ b/src/test/kotlin/com/ticketera/dto/eventSeats/NewEventSeatsDtoTest.kt
@@ -1,0 +1,17 @@
+package com.ticketera.dto.eventSeats
+
+import com.ticketera.TestData
+import org.assertj.core.api.Assertions
+import kotlin.test.Test
+
+class NewEventSeatsDtoTest : TestData() {
+
+    @Test
+    fun shouldCreateAListOfEventSeats() {
+        val seats = NewEventSeatsDto.newEventSeats(newEventSeatsDto, event, eventSector)
+
+        Assertions.assertThat(seats).isInstanceOf(List::class.java)
+        Assertions.assertThat(seats[0].seatNumber).isEqualTo("1")
+        Assertions.assertThat(seats[4].seatNumber).isEqualTo("5")
+    }
+}

--- a/src/test/kotlin/com/ticketera/repositories/EventSeatRepositoryTest.kt
+++ b/src/test/kotlin/com/ticketera/repositories/EventSeatRepositoryTest.kt
@@ -1,0 +1,72 @@
+package com.ticketera.repositories
+
+import com.ticketera.TestData
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+
+@Testcontainers
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+final class EventSeatRepositoryTest : TestData() {
+    @Autowired
+    private lateinit var eventSeatRepository: EventSeatRepository
+
+    @Autowired
+    private lateinit var entityManager: TestEntityManager
+
+
+    @BeforeEach
+    fun setup() {
+        entityManager.persistAndFlush(venue)
+        entityManager.persistAndFlush(event)
+        entityManager.persistAndFlush(eventSector)
+        entityManager.persistAndFlush(eventSeat)
+    }
+
+
+    @Test
+    fun shouldFindByEventId() {
+        assertThat(eventSeatRepository.findAllByEventId(eventId))
+            .isEqualTo(listOf(eventSeat))
+    }
+
+    @Test
+    fun shouldFindByEventIdAndSectorId() {
+        assertThat(eventSeatRepository.findAllByEventIdAndSectorId(eventId, eventSectorId))
+            .isEqualTo(listOf(eventSeat))
+    }
+
+    @Test
+    fun shouldDeleteByEventId() {
+        eventSeatRepository.deleteByEventId(eventId)
+        assertThat(eventSeatRepository.findById(eventSeatId))
+            .isEmpty
+    }
+
+    @Test
+    fun shouldDeleteByEventIdAndSectorId() {
+        eventSeatRepository.deleteByEventIdAndSectorId(eventId, eventSectorId)
+        assertThat(eventSeatRepository.findById(eventSeatId))
+            .isEmpty
+    }
+
+
+    companion object {
+        @Container
+        val postgres = TestContainerConf.postgres
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun registerProperties(registry: DynamicPropertyRegistry) =
+            TestContainerConf.registerProperties(registry)
+    }
+}

--- a/src/test/kotlin/com/ticketera/service/AuthHeadersServiceTest.kt
+++ b/src/test/kotlin/com/ticketera/service/AuthHeadersServiceTest.kt
@@ -5,7 +5,7 @@ import com.ticketera.model.UserRole
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class AuthHeadersServiceTest : TestData(){
+class AuthHeadersServiceTest : TestData() {
 
     private val authHeadersService = AuthHeadersService()
 
@@ -23,5 +23,10 @@ class AuthHeadersServiceTest : TestData(){
     @Test
     fun shouldValidateAdminOrOrganizer() {
         assertThat(authHeadersService.isAdminOrOrganizer(headersMap)).isTrue
+    }
+
+    @Test
+    fun shouldValidateAUser() {
+        assertThat(authHeadersService.isAUser(headersMap)).isTrue
     }
 }

--- a/src/test/kotlin/com/ticketera/service/EventSeatServiceTest.kt
+++ b/src/test/kotlin/com/ticketera/service/EventSeatServiceTest.kt
@@ -104,7 +104,7 @@ class EventSeatServiceTest : TestData() {
     fun shouldFindTheSeatsWithoutASector() {
         every { eventSeatRepository.findAllByEventId(any()) } returns listOf(eventSeat)
 
-        eventSeatService.findSeats(eventId)
+        assertThat(eventSeatService.findSeats(eventId)).isEqualTo(listOf(eventSeat))
 
         verify { eventSeatRepository.findAllByEventId(any()) }
     }
@@ -113,7 +113,7 @@ class EventSeatServiceTest : TestData() {
     fun shouldFindTheSeatsWithASector() {
         every { eventSeatRepository.findAllByEventIdAndSectorId(any(), any()) } returns listOf(eventSeat)
 
-        eventSeatService.findSeats(eventId, eventSectorId)
+        assertThat(eventSeatService.findSeats(eventId, eventSectorId)).isEqualTo(listOf(eventSeat))
 
         verify { eventSeatRepository.findAllByEventIdAndSectorId(any(), any()) }
     }

--- a/src/test/kotlin/com/ticketera/service/EventSeatServiceTest.kt
+++ b/src/test/kotlin/com/ticketera/service/EventSeatServiceTest.kt
@@ -1,0 +1,120 @@
+package com.ticketera.service
+
+import com.ticketera.TestData
+import com.ticketera.exceptions.TicketeraException
+import com.ticketera.model.EventSeat
+import com.ticketera.repositories.EventRepository
+import com.ticketera.repositories.EventSeatRepository
+import com.ticketera.repositories.EventSectorRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.runs
+import io.mockk.just
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.junit.jupiter.api.Test
+import java.util.Optional
+
+class EventSeatServiceTest : TestData() {
+
+    private val eventRepository: EventRepository = mockk()
+    private val eventSectorRepository: EventSectorRepository = mockk()
+    private val eventSeatRepository: EventSeatRepository = mockk()
+
+    private val eventSeatService = EventSeatService(
+        eventSeatRepository,
+        eventSectorRepository,
+        eventRepository
+    )
+
+    @Test
+    fun shouldGenerateTheSeatsAnSaveThem() {
+        every { eventSeatRepository.saveAll(any<List<EventSeat>>()) } returns listOf(eventSeat)
+        every { eventRepository.findById(any()) } returns Optional.of(event)
+        every { eventSectorRepository.findById(any()) } returns Optional.of(eventSector)
+
+        val saved = eventSeatService.generateEventSeats(newEventSeatsDto)
+
+        assertThat(saved).isEqualTo(listOf(eventSeat))
+
+        verify { eventRepository.findById(any()) }
+        verify { eventSectorRepository.findById(any()) }
+        verify { eventSeatRepository.saveAll(any<List<EventSeat>>()) }
+    }
+
+    @Test
+    fun shouldGenerateTheSeatsWithoutASector() {
+        every { eventSeatRepository.saveAll(any<List<EventSeat>>()) } returns listOf(eventSeat)
+        every { eventRepository.findById(any()) } returns Optional.of(event)
+
+        val saved = eventSeatService.generateEventSeats(newEventSeatsDto.copy(sectorId = null))
+
+        assertThat(saved).isEqualTo(listOf(eventSeat))
+
+        verify { eventRepository.findById(any()) }
+        verify { eventSeatRepository.saveAll(any<List<EventSeat>>()) }
+    }
+
+    @Test
+    fun shouldNotSaveSeatsWithoutAnEvent() {
+        every { eventRepository.findById(any()) } returns Optional.empty()
+
+        assertThatExceptionOfType(TicketeraException::class.java)
+            .isThrownBy {
+                eventSeatService.generateEventSeats(newEventSeatsDto)
+            }
+
+        verify { eventRepository.findById(any()) }
+    }
+
+    @Test
+    fun shouldNotSaveSeatsWithoutASectorWhenTheSectorIsPresent() {
+        every { eventRepository.findById(any()) } returns Optional.of(event)
+        every { eventSectorRepository.findById(any()) } returns Optional.empty()
+
+        assertThatExceptionOfType(TicketeraException::class.java)
+            .isThrownBy {
+                eventSeatService.generateEventSeats(newEventSeatsDto)
+            }
+
+        verify { eventRepository.findById(any()) }
+        verify { eventSectorRepository.findById(any()) }
+    }
+
+    @Test
+    fun shouldDeleteTheSeatsWithoutASector() {
+        every { eventSeatRepository.deleteByEventId(any()) } just runs
+
+        eventSeatService.deleteSeats(eventId)
+
+        verify { eventSeatRepository.deleteByEventId(any()) }
+    }
+
+    @Test
+    fun shouldDeleteTheSeatsWithASector() {
+        every { eventSeatRepository.deleteByEventIdAndSectorId(any(), any()) } just runs
+
+        eventSeatService.deleteSeats(eventId, eventSectorId)
+
+        verify { eventSeatRepository.deleteByEventIdAndSectorId(any(), any()) }
+    }
+
+    @Test
+    fun shouldFindTheSeatsWithoutASector() {
+        every { eventSeatRepository.findAllByEventId(any()) } returns listOf(eventSeat)
+
+        eventSeatService.findSeats(eventId)
+
+        verify { eventSeatRepository.findAllByEventId(any()) }
+    }
+
+    @Test
+    fun shouldFindTheSeatsWithASector() {
+        every { eventSeatRepository.findAllByEventIdAndSectorId(any(), any()) } returns listOf(eventSeat)
+
+        eventSeatService.findSeats(eventId, eventSectorId)
+
+        verify { eventSeatRepository.findAllByEventIdAndSectorId(any(), any()) }
+    }
+}


### PR DESCRIPTION
✅ Entity 
✅ Endpoint to upload/add seats to an event (Optional sector)
✅ Sector-aware seat creation (sector_id optional)
✅ GET /events/seats/{eventId}/all?sectorId=sdvg3443
✅ DELETE /events/seats/{eventId}/delete?sectorId=sdvg3443